### PR TITLE
Remove 4k video limit

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -12,6 +12,7 @@
             </intent-filter>
         </activity>
         <activity android:name=".VideoActivity" android:theme="@style/BaseTheme" />
+        <activity android:name=".VideoActivity4k" android:theme="@style/BaseTheme" />
         <activity android:name=".LanguageActivity" android:theme="@style/BaseTheme" />
         <activity android:name=".ProtectionActivity" android:theme="@style/BaseTheme" />
     </application>

--- a/app/src/main/java/com/github/ma1co/openmemories/tweak/BackupKeys.java
+++ b/app/src/main/java/com/github/ma1co/openmemories/tweak/BackupKeys.java
@@ -5,6 +5,8 @@ public class BackupKeys {
     public static final int REC_LIMIT_M = 0x003c0374;
     public static final int REC_LIMIT_S = 0x003c0375;
 
+    public static final int REC_LIMIT_4K = 0x003c04b6;
+
     private static final int LANGUAGE_ACTIVE_FIRST = 0x010d008f;
     private static final int LANGUAGE_ACTIVE_COUNT = 35;
     public static final int[] LANGUAGE_ACTIVE_LIST;

--- a/app/src/main/java/com/github/ma1co/openmemories/tweak/BaseActivity.java
+++ b/app/src/main/java/com/github/ma1co/openmemories/tweak/BaseActivity.java
@@ -4,6 +4,8 @@ import android.app.Activity;
 import android.app.AlertDialog;
 import android.view.KeyEvent;
 
+import java.nio.ByteBuffer;
+
 public class BaseActivity extends Activity {
     public static class BackupCheckException extends Exception {
         public BackupCheckException(String message) {
@@ -59,6 +61,28 @@ public class BaseActivity extends Activity {
                 }
             } catch (NativeException e) {
                 Logger.error("checkBackupByteValues", String.format("error reading 0x%x", id), e);
+                throw new BackupCheckException("Read failed");
+            }
+        }
+    }
+
+    protected void checkBackupHalfwordValues(int[] ids, int min, int max) throws BackupCheckException {
+        for (int id : ids) {
+            try {
+                int size = Backup.getSize(id);
+                if (size != 2) {
+                    Logger.error("checkBackupHalfwordValues", String.format("0x%x has wrong size: %d", id, size));
+                    throw new BackupCheckException("Cannot read settings file: Wrong data size");
+                }
+                byte[] bytes = Backup.getValue(id);
+                ByteBuffer bb = ByteBuffer.wrap(bytes);
+                int value = (int)bb.getShort() & 0x00ffff;
+                if (value < min || value > max) {
+                    Logger.error("checkBackupHalfwordValues", String.format("0x%x out of bounds: %d", id, value));
+                    throw new BackupCheckException("Cannot read settings file:  Value out of bounds");
+                }
+            } catch (NativeException e) {
+                Logger.error("checkBackupHalfwordValues", String.format("error reading 0x%x", id), e);
                 throw new BackupCheckException("Read failed");
             }
         }

--- a/app/src/main/java/com/github/ma1co/openmemories/tweak/BaseActivity.java
+++ b/app/src/main/java/com/github/ma1co/openmemories/tweak/BaseActivity.java
@@ -66,23 +66,23 @@ public class BaseActivity extends Activity {
         }
     }
 
-    protected void checkBackupHalfwordValues(int[] ids, int min, int max) throws BackupCheckException {
+    protected void checkBackupShortValues(int[] ids, int min, int max) throws BackupCheckException {
         for (int id : ids) {
             try {
                 int size = Backup.getSize(id);
                 if (size != 2) {
-                    Logger.error("checkBackupHalfwordValues", String.format("0x%x has wrong size: %d", id, size));
+                    Logger.error("checkBackupShortValues", String.format("0x%x has wrong size: %d", id, size));
                     throw new BackupCheckException("Cannot read settings file: Wrong data size");
                 }
                 byte[] bytes = Backup.getValue(id);
                 ByteBuffer bb = ByteBuffer.wrap(bytes);
                 int value = (int)bb.getShort() & 0x00ffff;
                 if (value < min || value > max) {
-                    Logger.error("checkBackupHalfwordValues", String.format("0x%x out of bounds: %d", id, value));
+                    Logger.error("checkBackupShortValues", String.format("0x%x out of bounds: %d", id, value));
                     throw new BackupCheckException("Cannot read settings file:  Value out of bounds");
                 }
             } catch (NativeException e) {
-                Logger.error("checkBackupHalfwordValues", String.format("error reading 0x%x", id), e);
+                Logger.error("checkBackupShortValues", String.format("error reading 0x%x", id), e);
                 throw new BackupCheckException("Read failed");
             }
         }

--- a/app/src/main/java/com/github/ma1co/openmemories/tweak/MainActivity.java
+++ b/app/src/main/java/com/github/ma1co/openmemories/tweak/MainActivity.java
@@ -26,8 +26,11 @@ public class MainActivity extends TabActivity {
         });
 
         addTab("video", "Video", android.R.drawable.ic_menu_camera, VideoActivity.class);
-        //todo: only show video4k tab if camera has the relevant backup key!
-        addTab("video4k", "4k Video", android.R.drawable.ic_menu_camera, VideoActivity4k.class);
+        try {
+            if (Backup.getSize(BackupKeys.REC_LIMIT_4K) == 2) {
+                addTab("video4k", "4k Video", android.R.drawable.ic_menu_camera, VideoActivity4k.class);
+            }
+        } catch(NativeException e) { /* no op */ }
         addTab("lang", "Languages", android.R.drawable.ic_menu_mapmode, LanguageActivity.class);
         addTab("protection", "Protection", android.R.drawable.ic_lock_lock, ProtectionActivity.class);
     }

--- a/app/src/main/java/com/github/ma1co/openmemories/tweak/MainActivity.java
+++ b/app/src/main/java/com/github/ma1co/openmemories/tweak/MainActivity.java
@@ -26,6 +26,8 @@ public class MainActivity extends TabActivity {
         });
 
         addTab("video", "Video", android.R.drawable.ic_menu_camera, VideoActivity.class);
+        //todo: only show video4k tab if camera has the relevant backup key!
+        addTab("video4k", "4k Video", android.R.drawable.ic_menu_camera, VideoActivity4k.class);
         addTab("lang", "Languages", android.R.drawable.ic_menu_mapmode, LanguageActivity.class);
         addTab("protection", "Protection", android.R.drawable.ic_lock_lock, ProtectionActivity.class);
     }

--- a/app/src/main/java/com/github/ma1co/openmemories/tweak/VideoActivity4k.java
+++ b/app/src/main/java/com/github/ma1co/openmemories/tweak/VideoActivity4k.java
@@ -1,0 +1,92 @@
+package com.github.ma1co.openmemories.tweak;
+
+import android.os.Bundle;
+import android.view.View;
+import android.widget.TextView;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+
+public class VideoActivity4k extends BaseActivity {
+    public static final int MIN_LIMIT = 5;
+    public static final int DEFAULT_LIMIT = 300;
+    public static final int MAX_LIMIT = 0x7fff;
+
+    private TextView limit4kTextView;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_video_4k);
+        limit4kTextView = (TextView) findViewById(R.id.limit4kTextView);
+    }
+
+    @Override
+    protected void onResume() {
+        super.onResume();
+        showCurrentLimit();
+    }
+
+    protected void readCheck() throws BackupCheckException {
+        checkBackupHalfwordValues(new int[] { BackupKeys.REC_LIMIT_4K }, 0, 0x00ffff);
+    }
+
+    protected void writeCheck() throws BackupCheckException {
+        checkBackupWritable(new int[] { BackupKeys.REC_LIMIT_4K });
+    }
+
+    protected int readLimit() throws NativeException {
+        byte[] bytes = Backup.getValue(BackupKeys.REC_LIMIT_4K);
+        ByteBuffer bb = ByteBuffer.wrap(bytes);
+        bb.order(ByteOrder.LITTLE_ENDIAN);
+        return (int)bb.getShort() & 0x00ffff;
+    }
+
+    protected void writeLimit(int limit) throws NativeException {
+        Backup.setValue(BackupKeys.REC_LIMIT_4K, new byte[] { (byte)limit, (byte)(limit >> 8) });
+    }
+
+    protected void showCurrentLimit() {
+        limit4kTextView.setText("???");
+        try {
+            Logger.info("showCurrentLimit", "attempting to read 4k video rec limit");
+            readCheck();
+            int limit = readLimit();
+            int hours = limit / 3600;
+            int minutes = (limit - (hours * 3600)) / 60;
+            int seconds = limit % 60;
+            limit4kTextView.setText(
+                    String.format("%dh %02dm %02ds", hours, minutes, seconds));
+            Logger.info("showCurrentLimit", "done: " + limit);
+        } catch (Exception e) {
+            Logger.error("showCurrentLimit", e);
+            showError(e);
+        }
+    }
+
+    protected void setLimit(int limit) {
+        try {
+            Logger.info("setLimit", "attempting to write 4k video rec limit: " + limit);
+            readCheck();
+            writeCheck();
+            writeLimit(limit);
+            showCurrentLimit();
+            Logger.info("setLimit", "done");
+        } catch (Exception e) {
+            Logger.error("setLimit", e);
+            showError(e);
+        }
+    }
+
+    public void onMinLimit4kButtonClicked(View view) {
+        setLimit(MIN_LIMIT);
+    }
+
+    public void onDefaultLimit4kButtonClicked(View view) {
+        setLimit(DEFAULT_LIMIT);
+    }
+
+    public void onMaxLimit4kButtonClicked(View view) {
+        setLimit(MAX_LIMIT);
+    }
+}

--- a/app/src/main/java/com/github/ma1co/openmemories/tweak/VideoActivity4k.java
+++ b/app/src/main/java/com/github/ma1co/openmemories/tweak/VideoActivity4k.java
@@ -28,7 +28,7 @@ public class VideoActivity4k extends BaseActivity {
     }
 
     protected void readCheck() throws BackupCheckException {
-        checkBackupHalfwordValues(new int[] { BackupKeys.REC_LIMIT_4K }, 0, 0x00ffff);
+        checkBackupShortValues(new int[] { BackupKeys.REC_LIMIT_4K }, 0, 0x00ffff);
     }
 
     protected void writeCheck() throws BackupCheckException {

--- a/app/src/main/res/layout/activity_video_4k.xml
+++ b/app/src/main/res/layout/activity_video_4k.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="vertical"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Current 4K video recording limit:"/>
+
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="center"
+        android:textSize="40sp"
+        android:padding="5sp"
+        android:id="@+id/limit4kTextView"/>
+
+    <Button
+        android:layout_width="200sp"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:text="Set to 5s (for testing)"
+        android:onClick="onMinLimit4kButtonClicked"/>
+
+    <Button
+        android:layout_width="200sp"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:text="Set to 5min (default)"
+        android:onClick="onDefaultLimit4kButtonClicked"/>
+
+    <Button
+        android:layout_width="200sp"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:text="Set to maximum"
+        android:onClick="onMaxLimit4kButtonClicked"/>
+
+</LinearLayout>


### PR DESCRIPTION
On cameras having a separate limit for 4k video recording (I only know of the rx100m4 so far), this will add a tab to the Tweak UI for removing that limit. The backup key for the 4k limit is not present in other cams, its value is a short indicating the number of seconds for the 4k recording limit.

It is parsed by libmprctrl.so in the rx100m4 firmware, see `MprCtrl::GetRecLimitTimeForFV()` at offset `.text:0001436C`. The instruction referencing the backup key is:
`.text:00014394   LDR   R0, =0x3C04B6`
which is passed into `BackupLib::GetEepData()`.

Tested on rx100m4. Also tested on a7r2 to ensure the tab doesn't show on that cam, as it doesn't have a separate 4k video limit.